### PR TITLE
Disable odometry plugin as it crashes ardupilot

### DIFF
--- a/config/pluginlists.yaml
+++ b/config/pluginlists.yaml
@@ -13,7 +13,6 @@ plugin_blacklist:
 - vision_speed_estimate
 - wheel_odometry
 - distance_sensor #include this to prevent continuous error stream message about DS sensor mapping
+- odom # Including this plugin seems to crash Arducopter
 
-plugin_whitelist:
-#- 'sys_*'
-- obstacle_distance
+plugin_whitelist: []


### PR DESCRIPTION
It appears that there is a bug in the ArduCopter handler for Odometry MAVLink messages, which causes a floating point exception and crashes the sim. We can disable the odom plugin (as in this PR) to prevent this. Alternatively, you could set [SIM_FLOAT_EXCEPT](https://ardupilot.org/copter/docs/parameters-Copter-stable-V4.4.0.html#sim-float-except-generate-floating-point-exceptions) to '0' which will prevent the sim from crashing on a floating point exception. 